### PR TITLE
Enabled automated license header checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+# IntelliJ files
+.idea/*
+*.iml
+*.ipr
+*.iws
+build-idea/
+out/
+
+# Include Copyright template for IntelliJ
+!.idea/copyright
+
+# Gradle files
+.gradle
+build
+
+# OSX files
+.DS_Store

--- a/.idea/copyright/SPDX_ALv2.xml
+++ b/.idea/copyright/SPDX_ALv2.xml
@@ -1,0 +1,6 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="notice" value="SPDX-License-Identifier: Apache-2.0&#10;&#10;The OpenSearch Contributors require contributions made to&#10;this file be licensed under the Apache-2.0 license or a&#10;compatible open source license.&#10;&#10;Modifications Copyright OpenSearch Contributors. See&#10;GitHub history for details." />
+    <option name="myName" value="SPDX-ALv2" />
+  </copyright>
+</component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,3 @@
+<component name="CopyrightManager">
+  <settings default="SPDX-ALv2" />
+</component>

--- a/build.gradle
+++ b/build.gradle
@@ -113,8 +113,7 @@ tasks.named("integTest").configure {
     it.dependsOn(project.tasks.named("bundlePlugin"))
 }
 
-//TODO enable license headers
-licenseHeaders.enabled = false
+licenseHeaders.enabled = true
 dependencyLicenses.enabled = false
 thirdPartyAudit.enabled = false
 validateNebulaPom.enabled = false

--- a/src/main/java/org/opensearch/search/asynchronous/settings/LegacyOpendistroAsynchronousSearchSettings.java
+++ b/src/main/java/org/opensearch/search/asynchronous/settings/LegacyOpendistroAsynchronousSearchSettings.java
@@ -1,3 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
 package org.opensearch.search.asynchronous.settings;
 
 import org.opensearch.common.settings.Setting;

--- a/src/test/java/org/opensearch/search/asynchronous/settings/AsynchronousSearchSettingsTests.java
+++ b/src/test/java/org/opensearch/search/asynchronous/settings/AsynchronousSearchSettingsTests.java
@@ -1,3 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
 package org.opensearch.search.asynchronous.settings;
 
 import org.junit.Before;

--- a/src/test/java/org/opensearch/search/asynchronous/utils/QuadConsumer.java
+++ b/src/test/java/org/opensearch/search/asynchronous/utils/QuadConsumer.java
@@ -1,4 +1,15 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
  *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").
@@ -11,16 +22,6 @@
  *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  *   express or implied. See the License for the specific language governing
  *   permissions and limitations under the License.
- */
-/*
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
 
 package org.opensearch.search.asynchronous.utils;


### PR DESCRIPTION
### Description
1. Added the SPDX license header to the files with missing license headers.
2. Re-enabled the 'licenseHeaders' check in the build.gradle file.
3. Added an IntelliJ copyright profile to auto-generate the SPDX license header.
4. Updated the .gitignore file.
 
### Issues Resolved
Related to - https://github.com/opensearch-project/opensearch-plugins/issues/49
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Ketan Verma <ketan9495@gmail.com>