### PR TITLE
Add support for creating snapshot build artifacts.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,29 +30,31 @@ jobs:
         with:
           repository: 'opensearch-project/OpenSearch'
           path: OpenSearch
-          ref: '1.0'
+          ref: '1.x'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.snapshot=false
+        run: |
+          ./gradlew publishToMavenLocal
+          ./gradlew :distribution:docker:assemble
       # dependencies: common-utils
       - name: Checkout common-utils
         uses: actions/checkout@v2
         with:
-          ref: '1.0'
+          ref: 'main'
           repository: 'opensearch-project/common-utils'
           path: common-utils
       - name: Build common-utils
         working-directory: ./common-utils
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0
+        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0-SNAPSHOT
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
         uses: actions/checkout@v2
       - name: Build with Gradle
-        run: ./gradlew build -Dopensearch.version=1.0.0
+        run: ./gradlew build -Dopensearch.version=1.1.0-SNAPSHOT
       - name: Pull and Run Docker for security tests
         run: |
-          version=1.0.0
-          plugin_version=1.0.0.0
+          version=1.1.0-SNAPSHOT
+          plugin_version=1.1.0.0-SNAPSHOT
           pwd=`pwd`
           echo $pwd
           cd ..
@@ -64,7 +66,7 @@ jobs:
 
           if docker pull opensearchstaging/opensearch:$version
           then
-            echo "FROM opensearchstaging/opensearch:$version" >> Dockerfile
+            echo "FROM docker.opensearch.org/opensearch:$version" >> Dockerfile
             echo "RUN if [ -d /usr/share/opensearch/plugins/opensearch-asynchronous-search ]; then /usr/share/opensearch/bin/opensearch-plugin remove opensearch-asynchronous-search; fi" >> Dockerfile
             echo "ADD asynchronous-search/build/distributions/opensearch-asynchronous-search-$plugin_version.zip /tmp/" >> Dockerfile
             echo "RUN /usr/share/opensearch/bin/opensearch-plugin install --batch file:/tmp/opensearch-asynchronous-search-$plugin_version.zip" >> Dockerfile

--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -39,15 +39,15 @@ jobs:
           path: common-utils
       - name: Build OpenSearch
         working-directory: ./OpenSearch
-        run: ./gradlew publishToMavenLocal -Dbuild.snapshot=false
+        run: ./gradlew publishToMavenLocal
       - name: Build common-utils
         working-directory: ./common-utils
-        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.0.0
+        run: ./gradlew publishToMavenLocal -Dopensearch.version=1.1.0-SNAPSHOT
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
         uses: actions/checkout@v2
       - name: Run integration tests with multi node config
-        run: ./gradlew integTest -PnumNodes=5 -Dopensearch.version=1.0.0
+        run: ./gradlew integTest -PnumNodes=5 -Dopensearch.version=1.1.0-SNAPSHOT
       - name: Upload failed logs
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -29,12 +29,12 @@ jobs:
         with:
           repository: 'opensearch-project/OpenSearch'
           path: OpenSearch
-          ref: '1.0'
+          ref: '1.x'
       # dependencies: common-utils
       - name: Checkout common-utils
         uses: actions/checkout@v2
         with:
-          ref: '1.0'
+          ref: 'main'
           repository: 'opensearch-project/common-utils'
           path: common-utils
       - name: Build OpenSearch

--- a/build.gradle
+++ b/build.gradle
@@ -10,11 +10,13 @@
  */
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch_version", "1.0.0")
         distribution = 'oss-zip'
         opensearch_group = "org.opensearch"
-        opensearchVersion = '1.0.0'
-        common_utils_version = '1.0.0.0'
+        isSnapshot = "true" == System.getProperty("build.snapshot", "true")
+        opensearch_version = System.getProperty("opensearch_version", "1.1.0-SNAPSHOT")
+        // 1.0.0 -> 1.0.0.0, and 1.0.0-SNAPSHOT -> 1.0.0.0-SNAPSHOT
+        opensearch_build = opensearch_version.replaceAll(/(\.\d)([^\d]*)$/, '$1.0$2')
+        common_utils_version = System.getProperty("common_utils.version", opensearch_build)
     }
 
     repositories {
@@ -69,15 +71,17 @@ ext {
     projectSubstitutions = [:]
     licenseFile = rootProject.file('LICENSE.txt')
     noticeFile = rootProject.file('NOTICE.txt')
-    isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
-
-group 'org.opensearch'
-version = "${opensearchVersion}.0"
 
 sourceCompatibility = 1.9
 
-
+allprojects {
+    group 'org.opensearch'
+    version = opensearch_version - '-SNAPSHOT' + '.0'
+    if (isSnapshot) {
+        version += "-SNAPSHOT"
+    }
+}
 
 dependencies {
     testCompile ('junit:junit:4.12') {


### PR DESCRIPTION
### Description
This change adds a build properties to enable creating snapshot artifacts. This makes sure the OpenSearch and common-utils dependencies have the correct versions.

Also update the GHA workflows accordingly to build and test snapshots.
 
### Issues Resolved
#30 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


Signed-off-by: Rabi Panda <adnapibar@gmail.com>