### PR TITLE
Update CI workflow to use OpenSearch 1.1 instead of 1.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Test and Build Workflow
-# This workflow is triggered on pull requests to master or a opendistro release branch
+# This workflow is triggered on pull requests to master or a opensearch release branch
 on:
   pull_request:
     branches:
@@ -30,7 +30,7 @@ jobs:
         with:
           repository: 'opensearch-project/OpenSearch'
           path: OpenSearch
-          ref: '1.x'
+          ref: '1.1'
       - name: Build OpenSearch
         working-directory: ./OpenSearch
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Test and Build Workflow
-# This workflow is triggered on pull requests to master or a opensearch release branch
+# This workflow is triggered on pull requests to master or a OpenSearch release branch
 on:
   pull_request:
     branches:
@@ -40,7 +40,7 @@ jobs:
       - name: Checkout common-utils
         uses: actions/checkout@v2
         with:
-          ref: 'main'
+          ref: '1.1'
           repository: 'opensearch-project/common-utils'
           path: common-utils
       - name: Build common-utils


### PR DESCRIPTION
### Description
Update CI workflow to use OpenSearch 1.1 instead of 1.x


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
