### PR TITLE
Add codeowners support to repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
+*   @opensearch-project/asynchronous-search


### PR DESCRIPTION
Signed-off-by: Ryan Bogan <rbogan@amazon.com>

### Description
Add codeowners support to repo

### Issues Resolved
Progress on
[Meta issue](https://github.com/opensearch-project/project-meta/issues/31)
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
