### PR TITLE
Updating CI workflows to run on all branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,14 +3,10 @@ name: Test and Build Workflow
 on:
   pull_request:
     branches:
-      - main
-      - opendistro-*
-      - plugin-dev
+      - "*"
   push:
     branches:
-      - main
-      - opendistro-*
-      - plugin-dev
+      - "*"
 
 jobs:
   linux-build:

--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -6,10 +6,10 @@ env:
 on:
   pull_request:
     branches:
-      - main
+      - "*"
   push:
     branches:
-      - main
+      - "*"
 
 jobs:
   build:


### PR DESCRIPTION
Signed-off-by: Sarat Vemulapalli <vemulapallisarat@gmail.com>

### Description
CI workflows are not being run in release branches. 
Updating them to run on all of them pro-actively, since GHA is cheap.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
