### PR TITLE
Bumping async search to 1.2.2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,14 +3,10 @@ name: Test and Build Workflow
 on:
   pull_request:
     branches:
-      - main
-      - opendistro-*
-      - plugin-dev
+      - *
   push:
     branches:
-      - main
-      - opendistro-*
-      - plugin-dev
+      - *
 
 jobs:
   build:
@@ -28,7 +24,7 @@ jobs:
       - name: Checkout Branch
         uses: actions/checkout@v2
       - name: Build with Gradle
-        run: ./gradlew build -Dopensearch.version=1.2.1-SNAPSHOT
+        run: ./gradlew build -Dopensearch.version=1.2.2-SNAPSHOT
       - name: Pull and Run Docker for security tests
         run: |
           version=1.1.0-SNAPSHOT

--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -6,10 +6,10 @@ env:
 on:
   pull_request:
     branches:
-      - main
+      - *
   push:
     branches:
-      - main
+      - *
 
 jobs:
   build:
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout Branch
         uses: actions/checkout@v2
       - name: Run integration tests with multi node config
-        run: ./gradlew integTest -PnumNodes=5 -Dopensearch.version=1.2.1-SNAPSHOT
+        run: ./gradlew integTest -PnumNodes=5 -Dopensearch.version=1.2.2-SNAPSHOT
       - name: Upload failed logs
         uses: actions/upload-artifact@v2
         if: failure()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         distribution = 'oss-zip'
         opensearch_group = "org.opensearch"
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        opensearch_version = System.getProperty("opensearch.version", "1.2.1-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "1.2.2-SNAPSHOT")
         // 1.0.0 -> 1.0.0.0, and 1.0.0-SNAPSHOT -> 1.0.0.0-SNAPSHOT
         opensearch_build = opensearch_version.replaceAll(/(\.\d)([^\d]*)$/, '$1.0$2')
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)


### PR DESCRIPTION
### Description
Bumping async search to 1.2.2.0
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
