### PR TITLE
Build on JDK 8, 11, 14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,16 +10,22 @@ on:
 
 jobs:
   linux-build:
+    strategy:
+      matrix:
+        java:
+          - 8
+          - 11
+          - 14
     # Job name
     name: Build Asynchronous Search
     # This job runs on Linux.
     runs-on: ubuntu-latest
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set Up JDK 14
+      - name: Set Up JDK ${{ matrix.java }}
         uses: actions/setup-java@v1
         with:
-          java-version: 14
+          java-version: ${{ matrix.java }}
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
         uses: actions/checkout@v2
@@ -27,8 +33,8 @@ jobs:
         run: ./gradlew build -Dopensearch.version=1.3.0-SNAPSHOT
       - name: Pull and Run Docker for security tests
         run: |
-          version=1.1.0-SNAPSHOT
-          plugin_version=1.1.0.0-SNAPSHOT
+          version=1.3.0-SNAPSHOT
+          plugin_version=1.3.0.0-SNAPSHOT
           pwd=`pwd`
           echo $pwd
           cd ..
@@ -94,10 +100,10 @@ jobs:
     runs-on: windows-latest
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set Up JDK 14
+      - name: Set Up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 14
+          java-version: 11
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
         uses: actions/checkout@v2
@@ -122,10 +128,10 @@ jobs:
     runs-on: macos-latest
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set Up JDK 14
+      - name: Set Up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 14
+          java-version: 11
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ GET /_plugins/_asynchronous_search/stats
 
 1. Check out this package from version control.
 2. Launch Intellij IDEA, choose **Import Project**, and select the `settings.gradle` file in the root of this package. 
-3. To build from the command line, set `JAVA_HOME` to point to a JDK >= 14 before running `./gradlew`.
+3. To build from the command line, set `JAVA_HOME` to point to a JDK >= 8 before running `./gradlew`.
   - Unix System
     1. `export JAVA_HOME=jdk-install-dir`: Replace `jdk-install-dir` with the JAVA_HOME directory of your system.
     2. `export PATH=$JAVA_HOME/bin:$PATH`

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,8 @@ ext {
     noticeFile = rootProject.file('NOTICE.txt')
 }
 
-sourceCompatibility = 1.9
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 allprojects {
     group 'org.opensearch'


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description

Added CI for JDK 8, 11 and 14.

### Issues Resolved

Closes https://github.com/opensearch-project/asynchronous-search/issues/66.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
