### PR TITLE
Adding support for integration tests with remote cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The project in this package uses the [Gradle](https://docs.gradle.org/current/us
 9. `./gradlew asynSearchCluster#rollingUpgradeClusterTask -Dtests.security.manager=false` launches a cluster with three nodes of bwc version of OpenSearch with async search plugin and tests backwards compatibility by performing rolling upgrade of all nodes with the current version of OpenSearch with async search plugin.
 10. `./gradlew asynSearchCluster#fullRestartClusterTask -Dtests.security.manager=false` launches a cluster with three nodes of bwc version of OpenSearch with async search plugin and tests backwards compatibility by performing a full restart on the cluster upgrading all the nodes with the current version of OpenSearch with async search plugin.
 11. `./gradlew bwcTestSuite -Dtests.security.manager=false` runs all the above bwc tests combined.
+12. `./gradlew integTestRemote -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="docker-cluster" -Dhttps=true -Duser=admin -Dpassword=admin` launches integration tests against a local cluster and run tests with security
 
 When launching a cluster using one of the above commands, logs are placed in `build/testclusters/integTest-0/logs`. Though the logs are teed to the console, in practices it's best to check the actual log file.
 

--- a/build.gradle
+++ b/build.gradle
@@ -193,6 +193,12 @@ task integTestRemote(type: RestIntegTestTask) {
     systemProperty "user", System.getProperty("user")
     systemProperty "password", System.getProperty("password")
 
+    if (System.getProperty("tests.rest.bwcsuite") == null) {
+        filter {
+            excludeTestsMatching "org.opensearch.search.asynchronous.bwc.*IT"
+        }
+    }
+
     // Only rest case can run with remote cluster
     if (System.getProperty("tests.rest.cluster") != null) {
         filter {

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@
  */
 import java.util.concurrent.Callable
 import org.opensearch.gradle.testclusters.StandaloneRestIntegTestTask
+import org.opensearch.gradle.test.RestIntegTestTask
 buildscript {
     ext {
         distribution = 'oss-zip'
@@ -176,6 +177,25 @@ integTest {
     if (System.getProperty("tests.rest.bwcsuite") == null) {
         filter {
             excludeTestsMatching "org.opensearch.search.asynchronous.bwc.*IT"
+        }
+    }
+}
+
+
+task integTestRemote(type: RestIntegTestTask) {
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    systemProperty 'tests.security.manager', 'false'
+    systemProperty 'java.io.tmpdir', opensearch_tmp_dir.absolutePath
+
+    systemProperty "https", System.getProperty("https")
+    systemProperty "user", System.getProperty("user")
+    systemProperty "password", System.getProperty("password")
+
+    // Only rest case can run with remote cluster
+    if (System.getProperty("tests.rest.cluster") != null) {
+        filter {
+            includeTestsMatching "org.opensearch.search.asynchronous.rest*"
         }
     }
 }

--- a/release-notes/opensearch-asynchronous-search.release-notes-1.3.0.0.md
+++ b/release-notes/opensearch-asynchronous-search.release-notes-1.3.0.0.md
@@ -1,0 +1,11 @@
+## Version 1.3.0.0 2022-03-12
+
+Compatible with OpenSearch 1.3.0
+
+### Infrastructure
+
+* Added backwards compatibility tests for async search([#95](https://github.com/opensearch-project/asynchronous-search/pull/95))
+
+### Maintenance
+
+* Removed jcenter([#94](https://github.com/opensearch-project/asynchronous-search/pull/94))


### PR DESCRIPTION
### Description
Adding support for integration tests with remote cluster. Tested the changes with OS 1.2.4 setup locally.
 
### Issues Resolved
[List any issues this PR will resolve]
https://github.com/opensearch-project/asynchronous-search/issues/63
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
