### PR TITLE
Changed master nomenclature to cluster_manager

### DIFF
--- a/src/main/java/org/opensearch/search/asynchronous/management/AsynchronousSearchManagementService.java
+++ b/src/main/java/org/opensearch/search/asynchronous/management/AsynchronousSearchManagementService.java
@@ -54,7 +54,8 @@ import java.util.stream.Stream;
 
 /**
  * The service takes care of cancelling ongoing searches which have been running past their expiration time and
- * cleaning up asynchronous search responses from disk by scheduling delete-by-query on master to be delegated to the least loaded node
+ * cleaning up asynchronous search responses from disk by scheduling delete-by-query on cluster_manager to be
+ * delegated to the least loaded node
  */
 public class AsynchronousSearchManagementService extends AbstractLifecycleComponent implements ClusterStateListener {
 
@@ -128,8 +129,8 @@ public class AsynchronousSearchManagementService extends AbstractLifecycleCompon
     @Override
     public void clusterChanged(ClusterChangedEvent event) {
         if (event.localNodeMaster() && persistedResponseCleanUpRunnable.get() == null) {
-            logger.trace("elected as master, triggering response cleanup tasks");
-            triggerCleanUp(event.state(), "became master");
+            logger.trace("elected as cluster_manager, triggering response cleanup tasks");
+            triggerCleanUp(event.state(), "became cluster_manager");
 
             final PersistedResponseCleanUpAndRescheduleRunnable newRunnable = new PersistedResponseCleanUpAndRescheduleRunnable();
             persistedResponseCleanUpRunnable.set(newRunnable);
@@ -274,7 +275,7 @@ public class AsynchronousSearchManagementService extends AbstractLifecycleCompon
             if (this == persistedResponseCleanUpRunnable.get()) {
                 super.doRun();
             } else {
-                logger.trace("master changed, scheduled cleanup job is stale");
+                logger.trace("cluster_manager changed, scheduled cleanup job is stale");
             }
         }
 

--- a/src/test/java/org/opensearch/search/asynchronous/utils/RestTestUtils.java
+++ b/src/test/java/org/opensearch/search/asynchronous/utils/RestTestUtils.java
@@ -257,8 +257,8 @@ public class RestTestUtils {
             return this;
         }
 
-        Params withMasterTimeout(TimeValue masterTimeout) {
-            return putParam("master_timeout", masterTimeout);
+        Params withClusterManagerTimeout(TimeValue clusterManagerTimeout) {
+            return putParam("cluster_manager_timeout", clusterManagerTimeout);
         }
 
         Params withPipeline(String pipeline) {


### PR DESCRIPTION
Signed-off-by: Dhrubajyoti Das <dhruvdas@amazon.com>

### Description
Changed 'master' nomenclature to 'cluster_manager'
 
### Issues Resolved
https://github.com/opensearch-project/asynchronous-search/issues/99
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
