### PR TITLE
Remove JDK 14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,6 @@ jobs:
       matrix:
         java:
           - 11
-          - 14
           - 17
     # Job name
     name: Build Asynchronous Search

--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -1,7 +1,7 @@
 name: Multi node test workflow
 
 env:
-  java_version: 14
+  java_version: 11
 # This workflow is triggered on pull requests to master
 on:
   pull_request:
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set Up JDK 14
+      - name: Set Up JDK 11
         uses: actions/setup-java@v1
         with:
           java-version: ${{ env.java_version }}

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [14]
+        java: [11,17]
     # Job name
     name: Build Asynchronous Search with JDK ${{ matrix.java }}
     # This job runs on Linux

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -1,7 +1,7 @@
 - [Developer Guide](#developer-guide)
     - [Forking and Cloning](#forking-and-cloning)
     - [Install Prerequisites](#install-prerequisites)
-        - [JDK 14](#jdk-14)
+        - [JDK 11](#jdk-11)
     - [Building](#building)
     - [Using IntelliJ IDEA](#using-intellij-idea)
     - [Submitting Changes](#submitting-changes)
@@ -16,9 +16,9 @@ Fork this repository on GitHub, and clone locally with `git clone`.
 
 ### Install Prerequisites
 
-#### JDK 14
+#### JDK 11
 
-OpenSearch components build using Java 14 at a minimum. This means you must have a JDK 14 installed with the environment variable `JAVA_HOME` referencing the path to Java home for your JDK 14 installation, e.g. `JAVA_HOME=/usr/lib/jvm/jdk-14`.
+OpenSearch components build using Java 11 at a minimum. This means you must have a JDK 11 installed with the environment variable `JAVA_HOME` referencing the path to Java home for your JDK 11 installation, e.g. `JAVA_HOME=/usr/lib/jvm/jdk-11`.
 
 ### Building
 


### PR DESCRIPTION
Signed-off-by: Bharathwaj G <bharath78910@gmail.com>

### Description
Dropping support for JDK 14
 
### Issues Resolved
https://github.com/opensearch-project/asynchronous-search/issues/121
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
