### PR TITLE
Remove rc1 build qualifier

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,9 +10,9 @@ buildscript {
         distribution = 'oss-zip'
         opensearch_group = "org.opensearch"
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        opensearch_version = System.getProperty("opensearch.version", "2.0.0-rc1-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.0.0-SNAPSHOT")
         opendistro_plugin_version = System.getProperty("bwc.version", "1.13.0.1")
-        buildVersionQualifier = System.getProperty("build.version_qualifier", "rc1")
+        buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         // 2.0.0-rc1-SNAPSHOT -> 2.0.0.0-rc1-SNAPSHOT
         version_tokens = opensearch_version.tokenize('-')
         opensearch_build = version_tokens[0] + '.0'


### PR DESCRIPTION
Signed-off-by: Bharathwaj G <bharath78910@gmail.com>

### Description
Remove rc1 build qualifier for GA release

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
