### PR TITLE
Add Forum link in Asynchronous Search plugin README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ Additionally, it is possible to attach one debugger to the cluster JVM and anoth
 ```
 
 
+## Getting Help
+
+If you find a bug, or have a feature request, please don't hesitate to open an issue in this repository.
+
+For more information, see the [project website](https://opensearch.org/) and [technical documentation](https://opensearch.org/docs/latest/search-plugins/async/index/). If you need help and are unsure where to open an issue, try the OpenSearch [Forum](https://forum.opensearch.org/).
 
 ## Security
 


### PR DESCRIPTION
Signed-off-by: cwillum <cwmmoore@amazon.com>

### Description
Added a "Getting Help" section that includes a link to the main OpenSearch product page, a link that goes direction to Asynchronous search in documentation, and a link to the OpenSearch Forum page.

### Issues Resolved
This more closely corresponds to the information  found in the README.md file in all of the other plugins bundled with OpenSearch.

This fixes the issue for the Asynchronous search plugin in [#921](https://github.com/opensearch-project/documentation-website/issues/921).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
