### PR TITLE
Changes to restrict user when backend roles are empty

### DIFF
--- a/release-notes/opensearch-asynchronous-search.release-notes-2.3.0.0.md
+++ b/release-notes/opensearch-asynchronous-search.release-notes-2.3.0.0.md
@@ -1,0 +1,7 @@
+## Version 2.3.0.0 2022-09-13
+
+Compatible with OpenSearch 2.3.0
+
+### Maintenance
+* bump version to 2.3.0 ([#](https://github.com/opensearch-project/asynchronous-search/pull/174))
+* Replace terminology 'master' with 'cluster manager' ([#175](https://github.com/opensearch-project/asynchronous-search/pull/175))

--- a/src/main/java/org/opensearch/search/asynchronous/utils/UserAuthUtils.java
+++ b/src/main/java/org/opensearch/search/asynchronous/utils/UserAuthUtils.java
@@ -52,10 +52,10 @@ public class UserAuthUtils {
 
     public static boolean isUserValid(@Nullable User currentUser, @Nullable User originalUser) {
         if(originalUser == null || currentUser == null) {
-            return false;
+            return true;
         }
-        if(currentUser.getBackendRoles() == null) {
-            return originalUser.getBackendRoles() == null;
+        if(currentUser.getBackendRoles() == null || originalUser.getBackendRoles() == null) {
+            return false;
         }
         return currentUser.getBackendRoles().containsAll(originalUser.getBackendRoles());
     }

--- a/src/main/java/org/opensearch/search/asynchronous/utils/UserAuthUtils.java
+++ b/src/main/java/org/opensearch/search/asynchronous/utils/UserAuthUtils.java
@@ -52,7 +52,7 @@ public class UserAuthUtils {
 
     public static boolean isUserValid(@Nullable User currentUser, @Nullable User originalUser) {
         if(originalUser == null || currentUser == null) {
-            return true;
+            return false;
         }
         if(currentUser.getBackendRoles() == null) {
             return originalUser.getBackendRoles() == null;


### PR DESCRIPTION
### Description
Users without back-end roles should not be able to see each-other's searches.

This is a breaking change as the users who were previously able to share info when backend roles are empty will not be able to share after this change unless they create backend roles and assign the same roles for the users to enable sharing.

```
PUT _plugins/_security/api/internalusers/judy
{
  "password": "judy",
  "backend_roles": [],
  "attributes": {}
}

PUT _plugins/_security/api/internalusers/elon
{
  "password": "elon",
  "backend_roles": [],
  "attributes": {}
}
Both judy and elon have full access to asynchronous search:

PUT _plugins/_security/api/rolesmapping/async_full_access
{
  "backend_roles": [],
  "hosts": [],
  "users": ["judy","elon"]
}

jack has read access to asynchronous search results:

PUT _plugins/_security/api/rolesmapping/async_read_access
{
  "backend_roles": [],
  "hosts": [],
  "users": ["jack"]
}
```

#### Before changes :

Because none of the users have backend roles, they will be able to see each other’s asynchronous searches. 
So, if judy submits an asynchronous search, elon, who has full access, will be able to see that search. 
jack, who has read access, will also be able to see judy’s asynchronous search.

#### After changes:
None of the users will be able to see each other’s asynchronous searches since the backend roles are empty. 

### Issues Resolved
https://github.com/opensearch-project/asynchronous-search/issues/169

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
