### PR TITLE
Integ test fix for testGetWithKeepAliveUpdate

### DIFF
--- a/src/test/java/org/opensearch/search/asynchronous/restIT/AsynchronousSearchRestIT.java
+++ b/src/test/java/org/opensearch/search/asynchronous/restIT/AsynchronousSearchRestIT.java
@@ -130,6 +130,7 @@ public class AsynchronousSearchRestIT extends AsynchronousSearchRestTestCase {
         submitAsynchronousSearchRequest.keepAlive(keepAlive);
         AsynchronousSearchResponse submitResponse = executeSubmitAsynchronousSearch(submitAsynchronousSearchRequest);
         GetAsynchronousSearchRequest getAsynchronousSearchRequest = new GetAsynchronousSearchRequest(submitResponse.getId());
+        keepAlive = TimeValue.timeValueHours(6);
         getAsynchronousSearchRequest.setKeepAlive(keepAlive);
         AsynchronousSearchResponse getResponse = executeGetAsynchronousSearch(getAsynchronousSearchRequest);
         assertThat(getResponse.getExpirationTimeMillis(), greaterThan(submitResponse.getExpirationTimeMillis()));


### PR DESCRIPTION
### Description

The window build is failing with the given below exception:

```
Suite: Test class org.opensearch.search.asynchronous.restIT.AsynchronousSearchRestIT
  2> Jan 18, 2023 7:36:20 AM org.opensearch.client.RestClient logResponse
  2> WARNING: request [POST https://localhost:9200/_opendistro/_asynchronous_search?keep_on_completion=true] returned 1 warnings: [299 OpenSearch-2.5.0-b8a8b6c4d7fc7a7e32eb2cb68ecad8057a4636ad "[POST /_opendistro/_asynchronous_search] is deprecated! Use [POST /_plugins/_asynchronous_search] instead."]
  2> REPRODUCE WITH: gradlew ':integTest' --tests "org.opensearch.search.asynchronous.restIT.AsynchronousSearchRestIT.testGetWithKeepAliveUpdate" -Dtests.seed=AA4C903AE61D33F9 -Dtests.security.manager=false -Dtests.locale=en-PH -Dtests.timezone=Asia/Vladivostok -Druntime.java=17
  2> java.lang.AssertionError: 
    Expected: a value greater than <1674009382007L>
         but: <1674009382007L> was equal to <1674009382007L>
```

The problem was the keep_alive was updated with the same value. This PR fixes that issue

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
