### PR TITLE
Increment version to 1.3.10 and update checksytle version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,11 +30,11 @@ jobs:
       - name: Checkout Branch
         uses: actions/checkout@v2
       - name: Build with Gradle
-        run: ./gradlew build -Dopensearch.version=1.3.9-SNAPSHOT
+        run: ./gradlew build -Dopensearch.version=1.3.10-SNAPSHOT
       - name: Pull and Run Docker for security tests
         run: |
-          version=1.3.9-SNAPSHOT
-          plugin_version=1.3.9.0-SNAPSHOT
+          version=1.3.10-SNAPSHOT
+          plugin_version=1.3.10.0-SNAPSHOT
           pwd=`pwd`
           echo $pwd
           cd ..
@@ -108,7 +108,7 @@ jobs:
       - name: Checkout Branch
         uses: actions/checkout@v2
       - name: Build with Gradle
-        run: ./gradlew.bat build -D"opensearch.version=1.3.9-SNAPSHOT" -x integTest -x jacocoTestReport
+        run: ./gradlew.bat build -D"opensearch.version=1.3.10-SNAPSHOT" -x integTest -x jacocoTestReport
         env:
           _JAVA_OPTIONS: -Xmx4096M
       - name: Create Artifact Path
@@ -136,7 +136,7 @@ jobs:
       - name: Checkout Branch
         uses: actions/checkout@v2
       - name: Build with Gradle
-        run: ./gradlew build -Dopensearch.version=1.3.9-SNAPSHOT -x integTest -x jacocoTestReport
+        run: ./gradlew build -Dopensearch.version=1.3.10-SNAPSHOT -x integTest -x jacocoTestReport
         env:
           _JAVA_OPTIONS: -Xmx4096M
       - name: Create Artifact Path

--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout Branch
         uses: actions/checkout@v2
       - name: Run integration tests with multi node config
-        run: ./gradlew integTest -PnumNodes=5 -Dopensearch.version=1.3.9-SNAPSHOT
+        run: ./gradlew integTest -PnumNodes=5 -Dopensearch.version=1.3.10-SNAPSHOT
       - name: Run Backwards Compatibility Tests
         run: |
           echo "Running backwards compatibility tests ..."

--- a/build.gradle
+++ b/build.gradle
@@ -9,10 +9,18 @@ buildscript {
         distribution = 'oss-zip'
         opensearch_group = "org.opensearch"
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        opensearch_version = System.getProperty("opensearch.version", "1.3.9-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "1.3.10-SNAPSHOT")
         // 1.0.0 -> 1.0.0.0, and 1.0.0-SNAPSHOT -> 1.0.0.0-SNAPSHOT
         opendistro_plugin_version = System.getProperty("bwc.version", "1.13.0.1")
-        opensearch_build = opensearch_version.replaceAll(/(\.\d)([^\d]*)$/, '$1.0$2')
+        buildVersionQualifier = System.getProperty("build.version_qualifier", "")
+        version_tokens = opensearch_version.tokenize('-')
+        opensearch_build = version_tokens[0] + '.0'
+        if (buildVersionQualifier) {
+            opensearch_build += "-${buildVersionQualifier}"
+        }
+        if (isSnapshot) {
+            opensearch_build += "-SNAPSHOT"
+        }
         common_utils_version = System.getProperty("common_utils.version", opensearch_build)
     }
 
@@ -52,7 +60,7 @@ apply plugin: 'opensearch.rest-test'
 
 
 checkstyle {
-    toolVersion = '8.24'
+    toolVersion = '8.29'
     configFile file("checkstyle/checkstyle.xml")
 }
 


### PR DESCRIPTION
### Description
Increment version to 1.3.10 and update checksytle version to 8.29 for addressing  CVE-2019-10782

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
