### PR TITLE
Fix number of total shards in partial search response

### DIFF
--- a/src/main/java/org/opensearch/search/asynchronous/listener/AsynchronousSearchProgressListener.java
+++ b/src/main/java/org/opensearch/search/asynchronous/listener/AsynchronousSearchProgressListener.java
@@ -68,7 +68,7 @@ public class AsynchronousSearchProgressListener extends SearchProgressActionList
     protected void onListShards(List<SearchShard> shards, List<SearchShard> skippedShards, SearchResponse.Clusters clusters,
                                 boolean fetchPhase) {
         partialResultsHolder.hasFetchPhase.set(fetchPhase);
-        partialResultsHolder.totalShards.set(shards.size());
+        partialResultsHolder.totalShards.set(shards.size() + skippedShards.size());
         partialResultsHolder.skippedShards.set(skippedShards.size());
         partialResultsHolder.successfulShards.set(skippedShards.size());
         partialResultsHolder.clusters.set(clusters);


### PR DESCRIPTION
### Description
The `totalShards` in `SearchResponse` includes skipped shards, but the partial search response in `AsynchronousSearchProgressListener` does not account for this.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
