### PR TITLE
Updates to maintainers and codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match with the users in MAINTAINERS.md file
-*   @Bukhtawar @bharath-techie @Arpit-Bandejiya @dhruv16dhr @pranikum
+*   @Bukhtawar @bharath-techie @Arpit-Bandejiya @dhruv16dhr @pranikum @mch2 @anddross @Poojita-Raj @kotwanikunal @Rishikesh1159

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,13 +4,18 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer      | GitHub ID                                             | Affiliation |
-|-----------------|-------------------------------------------------------|-------------|
-| Rishav Sagar    | [RS146BIJAY](https://github.com/RS146BIJAY)           | Amazon      |
-| Bharathwaj G    | [bharath-techie](https://github.com/bharath-techie)   | Amazon      |
-| Arpit Bandejiya | [Arpit-Bandejiya](https://github.com/Arpit-Bandejiya) | Amazon      |
-| Pranit Kumar    | [pranikum](https://github.com/pranikum)               | Amazon      |
-| Bukhtawar Khan  | [Bukhtawar](https://github.com/Bukhtawar)             | Amazon      |
+| Maintainer       | GitHub ID                                            | Affiliation |
+|------------------|------------------------------------------------------|-------------|
+| Rishav Sagar     | [RS146BIJAY](https://github.com/RS146BIJAY)          | Amazon      |
+| Bharathwaj G     | [bharath-techie](https://github.com/bharath-techie)  | Amazon      |
+| Arpit Bandejiya  | [Arpit-Bandejiya](https://github.com/Arpit-Bandejiya)| Amazon      |
+| Pranit Kumar     | [pranikum](https://github.com/pranikum)              | Amazon      |
+| Bukhtawar Khan   | [Bukhtawar](https://github.com/Bukhtawar)            | Amazon      |
+| Marc Handalian   | [mch2](https://github.com/mch2)                      | Amazon      |
+| Andrew Ross      | [andrross](https://github.com/andrross)              | Amazon      |
+| Kunal Kotwani    | [kotwanikunal](https://github.com/kotwanikunal)      | Amazon      |
+| Poojita Raj      | [Poojita-Raj](https://github.com/Poojita-Raj)        | Amazon      |
+| Rishikesh Pasham | [Bukhtawar](https://github.com/Rishikesh1159)        | Amazon      |
 
 ## Emeritus
 


### PR DESCRIPTION
Add mch2 anddross poojita-raj kotwanikunal and rishikesh1159 as maintainers

### Description
Add mch2 anddross poojita-raj kotwanikunal and rishikesh1159 as maintainers and codeowners.

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
