### PR TITLE
Fixed Github ID for maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,18 +4,18 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer       | GitHub ID                                            | Affiliation |
-|------------------|------------------------------------------------------|-------------|
-| Rishav Sagar     | [RS146BIJAY](https://github.com/RS146BIJAY)          | Amazon      |
-| Bharathwaj G     | [bharath-techie](https://github.com/bharath-techie)  | Amazon      |
-| Arpit Bandejiya  | [Arpit-Bandejiya](https://github.com/Arpit-Bandejiya)| Amazon      |
-| Pranit Kumar     | [pranikum](https://github.com/pranikum)              | Amazon      |
-| Bukhtawar Khan   | [Bukhtawar](https://github.com/Bukhtawar)            | Amazon      |
-| Marc Handalian   | [mch2](https://github.com/mch2)                      | Amazon      |
-| Andrew Ross      | [andrross](https://github.com/andrross)              | Amazon      |
-| Kunal Kotwani    | [kotwanikunal](https://github.com/kotwanikunal)      | Amazon      |
-| Poojita Raj      | [Poojita-Raj](https://github.com/Poojita-Raj)        | Amazon      |
-| Rishikesh Pasham | [Bukhtawar](https://github.com/Rishikesh1159)        | Amazon      |
+| Maintainer       | GitHub ID                                    | Affiliation |
+|------------------|----------------------------------------------|-------------|
+| Rishav Sagar     | [RS146BIJAY](https://github.com/RS146BIJAY)  | Amazon      |
+| Bharathwaj G     | [bharath-techie](https://github.com/bharath-techie) | Amazon      |
+| Arpit Bandejiya  | [Arpit-Bandejiya](https://github.com/Arpit-Bandejiya) | Amazon      |
+| Pranit Kumar     | [pranikum](https://github.com/pranikum)      | Amazon      |
+| Bukhtawar Khan   | [Bukhtawar](https://github.com/Bukhtawar)    | Amazon      |
+| Marc Handalian   | [mch2](https://github.com/mch2)              | Amazon      |
+| Andrew Ross      | [andrross](https://github.com/andrross)      | Amazon      |
+| Kunal Kotwani    | [kotwanikunal](https://github.com/kotwanikunal) | Amazon      |
+| Poojita Raj      | [Poojita-Raj](https://github.com/Poojita-Raj) | Amazon      |
+| Rishikesh Pasham | [Rishikesh1159](https://github.com/Rishikesh1159)         | Amazon      |
 
 ## Emeritus
 


### PR DESCRIPTION
### Description
Maintainer's github ID was mixed up. 
Rishikesh's ID was set to Bukhtawar. Just fixed that typo. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
