### PR TITLE
Fix bwcTests to point to correct 2.x version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,9 +11,7 @@ buildscript {
         opensearch_group = "org.opensearch"
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         opensearch_version = System.getProperty("opensearch.version", "3.0.0-SNAPSHOT")
-        opensearch_plugin_version = System.getProperty("bwc.version", "2.12.0.0")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
-        // 2.0.0-rc1-SNAPSHOT -> 2.0.0.0-rc1-SNAPSHOT
         version_tokens = opensearch_version.tokenize('-')
         opensearch_build = version_tokens[0] + '.0'
         if (buildVersionQualifier) {
@@ -261,11 +259,10 @@ ext.getPluginResource = { download_to_folder, download_from_src ->
 }
 
 String baseName = "asynSearchCluster"
-String bwcVersionShort = "2.12.0"
+String bwcVersionShort = "2.14.0"
 String bwcVersion = bwcVersionShort + ".0"
 String bwcFilePath = "src/test/resources/org/opensearch/search/asynchronous/bwc/"
 String bwcRemoteFile = "https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/"+ bwcVersionShort + "/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-asynchronous-search-"+ bwcVersion +".zip"
-//getPluginResource(bwcFilePath + bwcVersion, bwcRemoteFile)
 // Creates two test clusters of previous version and loads opensearch plugin of bwcVersion
 2.times { i ->
     testClusters {
@@ -279,7 +276,11 @@ String bwcRemoteFile = "https://ci.opensearch.org/ci/dbc/distribution-build-open
                     return new RegularFile() {
                         @Override
                         File getAsFile() {
-                            return fileTree(bwcFilePath + opensearch_plugin_version).getSingleFile()
+                            if (new File(bwcFilePath + bwcVersion).exists()) {
+                                project.delete(files(bwcFilePath + bwcVersion))
+                            }
+                            getPluginResource(bwcFilePath + bwcVersion, bwcRemoteFile)
+                            return fileTree(bwcFilePath + bwcVersion).getSingleFile()
                         }
                     }
                 }


### PR DESCRIPTION

### Description
Fix broken bwcTests on main, this will require a manual backport to 2.x for version correctness.
This change also removes the requirement to commit plugin zips to the repo and downloads them on demand.

### Issues Resolved
N/A 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
