### PR TITLE
Bump bwc version -> 2.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ build
 
 # OSX files
 .DS_Store
+
+# VSCode
+.vscode

--- a/build.gradle
+++ b/build.gradle
@@ -259,7 +259,7 @@ ext.getPluginResource = { download_to_folder, download_from_src ->
 }
 
 String baseName = "asynSearchCluster"
-String bwcVersionShort = "2.14.0"
+String bwcVersionShort = "2.15.0"
 String bwcVersion = bwcVersionShort + ".0"
 String bwcFilePath = "src/test/resources/org/opensearch/search/asynchronous/bwc/"
 String bwcRemoteFile = "https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/"+ bwcVersionShort + "/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-asynchronous-search-"+ bwcVersion +".zip"


### PR DESCRIPTION
- **Add .vscode to .gitignore.**
- **Bump bwc version -> 2.15.0.0.**

### Description
Increment version of opensearch + async search plugin packages 2.14 -> 2.15.
BWC test suite fails on main running 2.14 against the 3.0.0 SNAPSHOT.

`./gradlew bwcTestSuite`

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
