### PR TITLE
Update deprecated ClusterService constructor

### DIFF
--- a/src/test/java/org/opensearch/search/asynchronous/utils/TestUtils.java
+++ b/src/test/java/org/opensearch/search/asynchronous/utils/TestUtils.java
@@ -17,6 +17,7 @@ import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.test.ClusterServiceUtils;
 
 import java.io.IOException;
 import java.util.Map;
@@ -30,7 +31,7 @@ public class TestUtils {
 
     public static ClusterService createClusterService(Settings settings, ThreadPool threadPool, DiscoveryNode localNode,
                                                       ClusterSettings clusterSettings) {
-        ClusterService clusterService = new ClusterService(settings, clusterSettings, threadPool);
+        ClusterService clusterService = ClusterServiceUtils.createClusterService(settings, clusterSettings, threadPool);
         clusterService.setNodeConnectionsService(createNoOpNodeConnectionsService());
         ClusterState initialClusterState = ClusterState.builder(new ClusterName(TestUtils.class.getSimpleName()))
                 .nodes(DiscoveryNodes.builder()


### PR DESCRIPTION
### Description
ClusterService constructor deprecated by clusterManagerMetrics change.
https://github.com/opensearch-project/OpenSearch/commit/a254aa99e2221561c4de79a75d0de237eb759851#diff-944637c34088815d36760e219a0b4976bf492cdff44ef450b52ede0a13b0d9f0R104

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).