### PR TITLE
Bump bwc test version -> 2.17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -267,7 +267,7 @@ Boolean bwcBundleTest = (project.findProperty('customDistributionDownloadType') 
 When testing between major versions note that ONLY the latest minor release of the previous version is api compatible. 
 */
 
-String bwcVersion = "2.15.0.0"
+String bwcVersion = "2.17.0.0"
 String bwcVersionShort = bwcVersion.replaceAll(/\.0+$/, "")
 String nxtVersionShort = opensearch_version.replaceAll(/\.0+$/, "").replaceAll("-SNAPSHOT", "")
 


### PR DESCRIPTION
### Description
Bump bwc version to 2.16 for release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
