### PR TITLE
Mute testStatsAcrossNodes - Flaky

### DIFF
--- a/src/test/java/org/opensearch/search/asynchronous/integTests/AsynchronousSearchStatsIT.java
+++ b/src/test/java/org/opensearch/search/asynchronous/integTests/AsynchronousSearchStatsIT.java
@@ -105,6 +105,7 @@ public class AsynchronousSearchStatsIT extends AsynchronousSearchIntegTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/opensearch-project/asynchronous-search/issues/87")
     @TestLogging(value = "_root:DEBUG", reason = "flaky")
     public void testStatsAcrossNodes() throws InterruptedException, ExecutionException {
         TestThreadPool threadPool = null;


### PR DESCRIPTION
### Description
Mute flaky test `testStatsAcrossNodes` of `org.opensearch.search.asynchronous.integTests.AsynchronousSearchStatsIT`.

### Related Issues
#87

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/asynchronous-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
