### PR TITLE
Bump download and upload-artifact to v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         java:
           - 21
     # Job name
-    name: Build Asynchronous Search
+    name: Linux - Build Asynchronous Search
     # This job runs on Linux.
     outputs:
       build-test-linux: ${{ steps.step-build-test-linux.outputs.build-test-linux }}
@@ -131,7 +131,7 @@ jobs:
             ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="docker-cluster"
           fi
       - name: Upload failed logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: logs
@@ -139,7 +139,7 @@ jobs:
 
   windows-build:
     # Job name
-    name: Build Asynchronous Search
+    name: Windows - Build Asynchronous Search
     # This job runs on Windows.
     runs-on: windows-latest
     steps:
@@ -161,14 +161,14 @@ jobs:
           cp ./build/distributions/*.zip asynchronous-search-artifacts
       # This step uses the upload-artifact Github action: https://github.com/actions/upload-artifact
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: asynchronous-search-plugin-windows
           path: asynchronous-search-artifacts
 
   mac-os-build:
     # Job name
-    name: Build Asynchronous Search
+    name: MacOS - Build Asynchronous Search
     # This job runs on Mac OS.
     runs-on: macos-latest
     steps:
@@ -190,7 +190,7 @@ jobs:
           cp ./build/distributions/*.zip asynchronous-search-artifacts
       # This step uses the upload-artifact Github action: https://github.com/actions/upload-artifact
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: asynchronous-search-plugin-mac
           path: asynchronous-search-artifacts

--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -52,7 +52,7 @@ jobs:
           chown -R 1000:1000 `pwd`
           su `id -un 1000` -c "./gradlew bwcTestSuite -Dtests.security.manager=false"
       - name: Upload failed logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: logs

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -116,7 +116,7 @@ jobs:
           asset_content_type: application/zip
 
       - name: Upload Workflow Artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: asynchronous-search-plugin
           path: asynchronous-search-artifacts


### PR DESCRIPTION
### Description
https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/asynchronous-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
