### PR TITLE
Standardize build/test github actions and java versions

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+
+    env: # actions/checkout uses node 16
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
     steps:
       - name: GitHub App token
         id: github_app_token
@@ -22,7 +26,7 @@ jobs:
       - name: Get tag
         id: tag
         uses: dawidd6/action-get-tag@v1
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ncipollo/release-action@v1
         with:
           github_token: ${{ steps.github_app_token.outputs.token }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,12 @@ on:
     branches:
       - "*"
 
+anchors:
+  job_defaults: &job_defaults
+    strategy:
+      matrix:
+        java: [21]
+
 jobs:
   Get-CI-Image-Tag:
     uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
@@ -15,11 +21,8 @@ jobs:
       product: opensearch
 
   linux-build:
+    <<: *job_defaults
     needs: Get-CI-Image-Tag
-    strategy:
-      matrix:
-        java:
-          - 21
     # Job name
     name: Linux - Build Asynchronous Search
     # This job runs on Linux.
@@ -33,19 +36,19 @@ jobs:
       # need to switch to root so that github actions can install runner binary on container without permission issues.
       options: --user root
 
-    env:
+    env: # actions/checkout uses node 16
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set up JDK for build and test
+      - name: Set up JDK ${{ matrix.java }} for build and test
         uses: actions/setup-java@v4
         with:
           distribution: temurin # Temurin is a distribution of adoptium
-          java-version: 21
+          java-version: ${{ matrix.java }}
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build with Gradle
         id: step-build-test-linux
         run: |
@@ -61,23 +64,24 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - uses: actions/upload-artifact@v3
         with:
-          name: async-plugin-linux-21
+          name: async-plugin-linux-${{ matrix.java }}
           path: ${{ steps.step-build-test-linux.outputs.build-test-linux }}
           if-no-files-found: error
 
   linux-test-docker:
+    <<: *job_defaults
     needs: linux-build
-    strategy:
-      matrix:
-        java:
-          - 21
     # Job name
     name: Test Asynchronous Search with opensearchstaging docker
     # This job runs on Linux.
     runs-on: ubuntu-latest
+
+    env: # actions/checkout uses node 16
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - uses: actions/download-artifact@v3
         with:
           name: async-plugin-linux-${{ matrix.java }}
@@ -139,20 +143,25 @@ jobs:
           path: build/testclusters/integTest-*/logs/*
 
   windows-build:
+    <<: *job_defaults
     # Job name
     name: Windows - Build Asynchronous Search
     # This job runs on Windows.
     runs-on: windows-latest
+
+    env: # actions/checkout uses node 16
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set Up JDK 21
+      - name: Set Up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:
           distribution: temurin # Temurin is a distribution of adoptium
-          java-version: 21
+          java-version: ${{ matrix.java }}
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build with Gradle
         run: ./gradlew.bat build -x integTest -x jacocoTestReport
         env:
@@ -169,20 +178,25 @@ jobs:
           path: asynchronous-search-artifacts
 
   mac-os-build:
+    <<: *job_defaults
     # Job name
     name: MacOS - Build Asynchronous Search
     # This job runs on Mac OS.
     runs-on: macos-latest
+
+    env: # actions/checkout uses node 16
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set Up JDK 21
+      - name: Set Up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:
           distribution: temurin # Temurin is a distribution of adoptium
-          java-version: 21
+          java-version: ${{ matrix.java }}
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build with Gradle
         run: ./gradlew build -x integTest -x jacocoTestReport
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ anchors:
   job_defaults: &job_defaults
     strategy:
       matrix:
-        java: [21]
+        java: [ 11,17,21 ]
 
 jobs:
   Get-CI-Image-Tag:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,12 +8,6 @@ on:
     branches:
       - "*"
 
-anchors:
-  job_defaults: &job_defaults
-    strategy:
-      matrix:
-        java: [ 11,17,21 ]
-
 jobs:
   Get-CI-Image-Tag:
     uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
@@ -21,7 +15,9 @@ jobs:
       product: opensearch
 
   linux-build:
-    <<: *job_defaults
+    strategy:
+      matrix:
+        java: [ 11,17,21 ]
     needs: Get-CI-Image-Tag
     # Job name
     name: Linux - Build Asynchronous Search
@@ -73,7 +69,9 @@ jobs:
           if-no-files-found: error
 
   linux-test-docker:
-    <<: *job_defaults
+    strategy:
+      matrix:
+        java: [ 11,17,21 ]
     needs: linux-build
     # Job name
     name: Test Asynchronous Search with opensearchstaging docker
@@ -147,7 +145,9 @@ jobs:
           path: build/testclusters/integTest-*/logs/*
 
   windows-build:
-    <<: *job_defaults
+    strategy:
+      matrix:
+        java: [ 11,17,21 ]
     # Job name
     name: Windows - Build Asynchronous Search
     # This job runs on Windows.
@@ -179,7 +179,9 @@ jobs:
           path: asynchronous-search-artifacts
 
   mac-os-build:
-    <<: *job_defaults
+    strategy:
+      matrix:
+        java: [ 11,17,21 ]
     # Job name
     name: MacOS - Build Asynchronous Search
     # This job runs on Mac OS.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
   linux-build:
     strategy:
       matrix:
-        java: [ 11,17,21 ]
+        java: [ 21 ]
     needs: Get-CI-Image-Tag
     # Job name
     name: Linux - Build Asynchronous Search
@@ -71,7 +71,7 @@ jobs:
   linux-test-docker:
     strategy:
       matrix:
-        java: [ 11,17,21 ]
+        java: [ 21 ]
     needs: linux-build
     # Job name
     name: Test Asynchronous Search with opensearchstaging docker
@@ -147,7 +147,7 @@ jobs:
   windows-build:
     strategy:
       matrix:
-        java: [ 11,17,21 ]
+        java: [ 21 ]
     # Job name
     name: Windows - Build Asynchronous Search
     # This job runs on Windows.
@@ -181,7 +181,7 @@ jobs:
   mac-os-build:
     strategy:
       matrix:
-        java: [ 11,17,21 ]
+        java: [ 21 ]
     # Job name
     name: MacOS - Build Asynchronous Search
     # This job runs on Mac OS.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,19 +36,23 @@ jobs:
       # need to switch to root so that github actions can install runner binary on container without permission issues.
       options: --user root
 
-    env: # actions/checkout uses node 16
+    # actions/checkout@v4 and actions/setup-java@v4 use node 20:
+    # https://github.com/actions/checkout/releases/tag/v4.0.0
+    # container image does not have GLIBC_2.28 required for this node version
+    # as such use @v3 actions instead for this workflow and set ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION
+    env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
       - name: Set up JDK ${{ matrix.java }} for build and test
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v3
         with:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: ${{ matrix.java }}
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
       - name: Build with Gradle
         id: step-build-test-linux
         run: |
@@ -81,7 +85,7 @@ jobs:
 
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
         with:
           name: async-plugin-linux-${{ matrix.java }}
@@ -149,19 +153,16 @@ jobs:
     # This job runs on Windows.
     runs-on: windows-latest
 
-    env: # actions/checkout uses node 16
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
       - name: Set Up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v3
         with:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: ${{ matrix.java }}
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
       - name: Build with Gradle
         run: ./gradlew.bat build -x integTest -x jacocoTestReport
         env:
@@ -184,19 +185,16 @@ jobs:
     # This job runs on Mac OS.
     runs-on: macos-latest
 
-    env: # actions/checkout uses node 16
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
       - name: Set Up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v3
         with:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: ${{ matrix.java }}
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
       - name: Build with Gradle
         run: ./gradlew build -x integTest -x jacocoTestReport
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,10 +38,11 @@ jobs:
 
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set Up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1
+      - name: Set up JDK for build and test
+        uses: actions/setup-java@v4
         with:
-          java-version: ${{ matrix.java }}
+          distribution: temurin # Temurin is a distribution of adoptium
+          java-version: 21
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
         uses: actions/checkout@v2
@@ -60,7 +61,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
       - uses: actions/upload-artifact@v3
         with:
-          name: async-plugin-linux-${{ matrix.java }}
+          name: async-plugin-linux-21
           path: ${{ steps.step-build-test-linux.outputs.build-test-linux }}
           if-no-files-found: error
 
@@ -145,8 +146,9 @@ jobs:
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
       - name: Set Up JDK 21
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: temurin # Temurin is a distribution of adoptium
           java-version: 21
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
@@ -174,8 +176,9 @@ jobs:
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
       - name: Set Up JDK 21
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: temurin # Temurin is a distribution of adoptium
           java-version: 21
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -15,13 +15,16 @@ jobs:
       id-token: write
       contents: write
 
+    env: # actions/checkout uses node 16
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
     steps:
-      - name: Set Up JDK
+      - name: Set Up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:
           distribution: temurin # Temurin is a distribution of adoptium
-          java-version: 21
-      - uses: actions/checkout@v3
+          java-version: ${{ matrix.java }}
+      - uses: actions/checkout@v4
       - uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -9,6 +9,10 @@ on:
 
 jobs:
   build-and-publish-snapshots:
+    strategy:
+      matrix:
+        java: [ 11,17,21 ]
+
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -19,9 +19,6 @@ jobs:
       id-token: write
       contents: write
 
-    env: # actions/checkout uses node 16
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-
     steps:
       - name: Set Up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -16,10 +16,11 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/setup-java@v3
+      - name: Set Up JDK
+        uses: actions/setup-java@v4
         with:
           distribution: temurin # Temurin is a distribution of adoptium
-          java-version: 11
+          java-version: 21
       - uses: actions/checkout@v3
       - uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -31,20 +31,24 @@ jobs:
       # need to switch to root so that github actions can install runner binary on container without permission issues.
       options: --user root
 
-    env: # actions/checkout uses node 16
+    # actions/checkout@v4 and actions/setup-java@v4 use node 20:
+    # https://github.com/actions/checkout/releases/tag/v4.0.0
+    # container image does not have GLIBC_2.28 required for this node version
+    # as such use @v3 actions instead for this workflow and set ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION
+    env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
       - name: Set Up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v3
         with:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: ${{ matrix.java }}
 
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
       - name: Run integration tests with multi node config
         run: |
           chown -R 1000:1000 `pwd`

--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -9,12 +9,6 @@ on:
     branches:
       - "*"
 
-anchors:
-  job_defaults: &job_defaults
-    strategy:
-      matrix:
-        java: [21]
-
 jobs:
   Get-CI-Image-Tag:
     uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
@@ -22,6 +16,9 @@ jobs:
       product: opensearch
 
   build:
+    strategy:
+      matrix:
+        java: [ 21 ]
     # Job name
     needs: Get-CI-Image-Tag
     name: Build Asynchronous Search

--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -9,6 +9,12 @@ on:
     branches:
       - "*"
 
+anchors:
+  job_defaults: &job_defaults
+    strategy:
+      matrix:
+        java: [21]
+
 jobs:
   Get-CI-Image-Tag:
     uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
@@ -28,20 +34,20 @@ jobs:
       # need to switch to root so that github actions can install runner binary on container without permission issues.
       options: --user root
 
-    env:
+    env: # actions/checkout uses node 16
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set Up JDK
+      - name: Set Up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:
           distribution: temurin # Temurin is a distribution of adoptium
-          java-version: 21
+          java-version: ${{ matrix.java }}
 
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Run integration tests with multi node config
         run: |
           chown -R 1000:1000 `pwd`

--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -1,7 +1,5 @@
 name: Multi node test workflow
 
-env:
-  java_version: 21
 # This workflow is triggered on pull requests to master
 on:
   pull_request:
@@ -35,10 +33,12 @@ jobs:
 
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set Up JDK 21
-        uses: actions/setup-java@v1
+      - name: Set Up JDK
+        uses: actions/setup-java@v4
         with:
-          java-version: ${{ env.java_version }}
+          distribution: temurin # Temurin is a distribution of adoptium
+          java-version: 21
+
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
         uses: actions/checkout@v2

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -23,9 +23,10 @@ jobs:
       - name: Checkout Branch
         uses: actions/checkout@v2
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set Up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1
+      - name: Set Up JDK
+        uses: actions/setup-java@v4
         with:
+          distribution: temurin # Temurin is a distribution of adoptium
           java-version: ${{ matrix.java }}
 
       # Building zip, deb and rpm files

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [11,17,21]
+        java: [21]
     # Job name
     name: Build Asynchronous Search with JDK ${{ matrix.java }}
     # This job runs on Linux

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -18,12 +18,16 @@ jobs:
     name: Build Asynchronous Search with JDK ${{ matrix.java }}
     # This job runs on Linux
     runs-on: ubuntu-latest
+
+    env: # actions/checkout uses node 16
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
     steps:
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set Up JDK
+      - name: Set Up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:
           distribution: temurin # Temurin is a distribution of adoptium

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -19,9 +19,6 @@ jobs:
     # This job runs on Linux
     runs-on: ubuntu-latest
 
-    env: # actions/checkout uses node 16
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-
     steps:
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch


### PR DESCRIPTION
### Description
Remove hard coded java versions - use java.matrix instead so we can easily add and remove java versions for each workflow. Build/publish/release with all supported versions - 11/17/21. Test only with java 21.

Standardize version of github actions:
actions/setup-java to v4
actions/checkout to v4

For containerized workflows the image published by opensearch-build does not have a high enough version of glibc to support these v4 actions. Here we downgrade to v3 which only needs node 16 and set `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true.

### Related Issues
Should fix publish failure with java upgrade for that workflow: 11 -> 21.

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/asynchronous-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
