### PR TITLE
Remove version truncate to fix nightly build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -269,7 +269,7 @@ When testing between major versions note that ONLY the latest minor release of t
 
 String bwcVersion = "2.18.0.0"
 String bwcVersionShort = bwcVersion.replaceAll(/\.0+$/, "")
-String nxtVersionShort = opensearch_version.replaceAll(/\.0+$/, "").replaceAll("-SNAPSHOT", "")
+String nxtVersionShort = opensearch_version.replaceAll("-SNAPSHOT", "")
 
 String baseName = "asynSearchCluster"
 String bwcFilePath = "src/test/resources/org/opensearch/search/asynchronous/bwc/"


### PR DESCRIPTION
### Description
Nightlies failing due to opensearch_version being unnecessarily truncated.
https://build.ci.opensearch.org/blue/organizations/jenkins/distribution-build-opensearch/detail/distribution-build-opensearch/10311/pipeline/170/

```
1: Task failed with an exception.

-----------

* Where:

Build file '/tmp/tmph0d2bvyo/asynchronous-search/build.gradle' line: 283



* What went wrong:

A problem occurred evaluating root project 'asynchronous-search'.

> Invalid version format: '3.0'. Should be major.minor.revision[-(alpha|beta|rc)Number][-SNAPSHOT]
```

### Related Issues
Likely reason 3.0.0 docker images are not being published.
Resolves #607

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/asynchronous-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
