### PR TITLE
Publish workflow to java 21 only

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -11,7 +11,7 @@ jobs:
   build-and-publish-snapshots:
     strategy:
       matrix:
-        java: [ 11,17,21 ]
+        java: [ 21 ]
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
### Description
This step continues to fail due build.gradle `sourceCompatibility = JavaVersion.VERSION_21` requirement.
Limit publish workflow to java 21 only.

### Related Issues
N/A

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/asynchronous-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
