### PR TITLE
Bump bwc version to 2.19 on main

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -267,7 +267,7 @@ Boolean bwcBundleTest = (project.findProperty('customDistributionDownloadType') 
 When testing between major versions note that ONLY the latest minor release of the previous version is api compatible.
 */
 
-String bwcVersion = "2.18.0.0"
+String bwcVersion = "2.19.0.0"
 String bwcVersionShort = bwcVersion.replaceAll(/\.0+$/, "")
 String nxtVersionShort = opensearch_version.replaceAll("-SNAPSHOT", "")
 


### PR DESCRIPTION
### Description

Bump bwc version to 2.19 on main

This version bump is needed for backward compatibility testing on main since opensearch core has been version bumped to 2.19 and 3.0.0 nodes can only form a cluster with the last minor version (2.19 as of now) of the previous major version (2.x).

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/asynchronous-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
