### PR TITLE
Fix ci version parsing script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,9 +90,9 @@ jobs:
       - name: Pull and Run Docker for security tests
         run: |
           plugin=${{ needs.linux-build.outputs.build-test-linux }}
-          version=`echo $plugin|awk -F- '{print $3}'| cut -d. -f 1-3`
-          plugin_version=`echo $plugin|awk -F- '{print $3}'| cut -d. -f 1-4`
-          qualifier=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-1`
+          version=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-3`
+          plugin_version=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-4`
+          qualifier=`echo $plugin|awk -F- '{print $5}'| cut -d. -f 1-1`
 
           if [ -n "$qualifier" ] && [ "$qualifier" != "SNAPSHOT" ]; then
               qualifier=-${qualifier}


### PR DESCRIPTION
### Description
[This](https://github.com/opensearch-project/asynchronous-search/blob/main/.github/workflows/build.yml#L90-L95) build.yml script is slightly off due to the extra '-' in "asynchronous-search".
Current output:
```
plugin version plugin_version qualifier docker_version
(opensearch-asynchronous-search-3.0.0.0-SNAPSHOT.zip) (search) (search) (-3) (search-3)
/home/runner/work/asynchronous-search/asynchronous-search
-rw-r--r-- 1 runner docker 980985 Nov  4 20:14 ./opensearch-asynchronous-search-3.0.0.0-SNAPSHOT.zip
Error response from daemon: manifest for opensearchstaging/opensearch:search-3 not found: manifest unknown: manifest unknown
```

Off by one error fixed:

```
plugin=opensearch-asynchronous-search-3.0.0.0-SNAPSHOT.zip
version=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-3`
plugin_version=`echo $plugin|awk -F- '{print $4}'| cut -d. -f 1-4`
qualifier=`echo $plugin|awk -F- '{print $5}'| cut -d. -f 1-1`
```
```
echo $version
3.0.0
echo $plugin_version
3.0.0.0
echo $qualifier
SNAPSHOT
```



### Related Issues
N/A

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/asynchronous-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
