### PR TITLE
Move linux-build off container, onto ubuntu-latest runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,11 +9,6 @@ on:
       - "*"
 
 jobs:
-  Get-CI-Image-Tag:
-    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
-    with:
-      product: opensearch
-
   linux-build:
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,15 @@ jobs:
       - name: Checkout Branch
         uses: actions/checkout@v3
       - name: Build with Gradle
-        run: ./gradlew build -x integTest -x jacocoTestReport
+        id: step-build-test-linux
+        run: |
+          ./gradlew build -x integTest -x jacocoTestReport
+          plugin=`basename $(ls build/distributions/*.zip)`
+          echo plugin $plugin
+          mv -v build/distributions/$plugin ./
+          echo "build-test-linux=$plugin" >> $GITHUB_OUTPUT
+        env:
+          _JAVA_OPTIONS: -Xmx4096M
       - name: Create Artifact Path
         run: |
           mkdir -p asynchronous-search-artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,30 +18,14 @@ jobs:
     strategy:
       matrix:
         java: [ 21 ]
-    needs: Get-CI-Image-Tag
     # Job name
     name: Linux - Build Asynchronous Search
-    # This job runs on Linux.
-    outputs:
-      build-test-linux: ${{ steps.step-build-test-linux.outputs.build-test-linux }}
+    # This job runs on Ubuntu.
     runs-on: ubuntu-latest
-    container:
-      # using the same image which is used by opensearch-build team to build the OpenSearch Distribution
-      # this image tag is subject to change as more dependencies and updates will arrive over time
-      image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
-      # need to switch to root so that github actions can install runner binary on container without permission issues.
-      options: --user root
-
-    # actions/checkout@v4 and actions/setup-java@v4 use node 20:
-    # https://github.com/actions/checkout/releases/tag/v4.0.0
-    # container image does not have GLIBC_2.28 required for this node version
-    # as such use @v3 actions instead for this workflow and set ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION
-    env:
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set up JDK ${{ matrix.java }} for build and test
+      - name: Set Up JDK ${{ matrix.java }}
         uses: actions/setup-java@v3
         with:
           distribution: temurin # Temurin is a distribution of adoptium
@@ -50,19 +34,18 @@ jobs:
       - name: Checkout Branch
         uses: actions/checkout@v3
       - name: Build with Gradle
-        id: step-build-test-linux
+        run: ./gradlew build -x integTest -x jacocoTestReport
+      - name: Create Artifact Path
         run: |
-          chown -R 1000:1000 `pwd`
-          su `id -un 1000` -c "./gradlew build"
-          plugin=`basename $(ls build/distributions/*.zip)`
-          echo plugin $plugin
-          mv -v build/distributions/$plugin ./
-          echo "build-test-linux=$plugin" >> $GITHUB_OUTPUT
+          mkdir -p asynchronous-search-artifacts
+          cp ./build/distributions/*.zip asynchronous-search-artifacts
+      # This step uses the upload-artifact Github action: https://github.com/actions/upload-artifact
       - name: Uploads coverage
         uses: codecov/codecov-action@v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-      - uses: actions/upload-artifact@v3
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
         with:
           name: async-plugin-linux-${{ matrix.java }}
           path: ${{ steps.step-build-test-linux.outputs.build-test-linux }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,10 +43,6 @@ jobs:
           echo "build-test-linux=$plugin" >> $GITHUB_OUTPUT
         env:
           _JAVA_OPTIONS: -Xmx4096M
-      - name: Create Artifact Path
-        run: |
-          mkdir -p asynchronous-search-artifacts
-          cp ./build/distributions/*.zip asynchronous-search-artifacts
       # This step uses the upload-artifact Github action: https://github.com/actions/upload-artifact
       - name: Uploads coverage
         uses: codecov/codecov-action@v1.2.1

--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -10,33 +10,14 @@ on:
       - "*"
 
 jobs:
-  Get-CI-Image-Tag:
-    uses: opensearch-project/opensearch-build/.github/workflows/get-ci-image-tag.yml@main
-    with:
-      product: opensearch
-
   build:
     strategy:
       matrix:
         java: [ 21 ]
     # Job name
-    needs: Get-CI-Image-Tag
     name: Build Asynchronous Search
     # This job runs on Linux
     runs-on: ubuntu-latest
-    container:
-      # using the same image which is used by opensearch-build team to build the OpenSearch Distribution
-      # this image tag is subject to change as more dependencies and updates will arrive over time
-      image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
-      # need to switch to root so that github actions can install runner binary on container without permission issues.
-      options: --user root
-
-    # actions/checkout@v4 and actions/setup-java@v4 use node 20:
-    # https://github.com/actions/checkout/releases/tag/v4.0.0
-    # container image does not have GLIBC_2.28 required for this node version
-    # as such use @v3 actions instead for this workflow and set ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION
-    env:
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
@@ -45,19 +26,16 @@ jobs:
         with:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: ${{ matrix.java }}
-
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
         uses: actions/checkout@v3
       - name: Run integration tests with multi node config
         run: |
-          chown -R 1000:1000 `pwd`
-          su `id -un 1000` -c "./gradlew integTest -PnumNodes=5"
+          ./gradlew integTest -PnumNodes=5
       - name: Run Backwards Compatibility Tests
         run: |
           echo "Running backwards compatibility tests ..."
-          chown -R 1000:1000 `pwd`
-          su `id -un 1000` -c "./gradlew bwcTestSuite -Dtests.security.manager=false"
+          ./gradlew bwcTestSuite -Dtests.security.manager=false
       - name: Upload failed logs
         uses: actions/upload-artifact@v3
         if: failure()


### PR DESCRIPTION
### Description
Prepping ci for #666.
The main blocker for bumping all github actions past v3 is illustrated by [this comment](https://github.com/opensearch-project/asynchronous-search/blob/main/.github/workflows/build.yml#L35):

```
# actions/checkout@v4 and actions/setup-java@v4 use node 20:
# https://github.com/actions/checkout/releases/tag/v4.0.0
# container image does not have GLIBC_2.28 required for this node version
# as such use @v3 actions instead for this workflow and set ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION
```

As such, this dependency on the opensearch-build docker container is problematic. Taking a look at the security plugin it seems like they forgo the opensearch-build container and run natively on `linux-build` instead. I cannot think of a reason why we can't do the same and am unsure why the linux build needs to be run on a docker container in the first place.

This pr moves the `linux-build` stage off this docker container.

### Related Issues
#666
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/asynchronous-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
