### PR TITLE
[Backport 2.19] Backport github action updates 

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -11,10 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+
+    env: # actions/checkout uses node 16
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
     steps:
       - name: GitHub App token
         id: github_app_token
-        uses: tibdex/github-app-token@v1.5.0
+        uses: tibdex/github-app-token@v2.1.0
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -22,7 +26,7 @@ jobs:
       - name: Get tag
         id: tag
         uses: dawidd6/action-get-tag@v1
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ncipollo/release-action@v1
         with:
           github_token: ${{ steps.github_app_token.outputs.token }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,33 +15,30 @@ jobs:
       product: opensearch
 
   linux-build:
-    needs: Get-CI-Image-Tag
     strategy:
       matrix:
-        java:
-          - 11
-          - 17
-          - 21
+        java: [ 21 ]
+    needs: Get-CI-Image-Tag
     # Job name
     name: Linux - Build Asynchronous Search
-    # This job runs on Linux.
     outputs:
       build-test-linux: ${{ steps.step-build-test-linux.outputs.build-test-linux }}
+    # This job runs on Linux.
     runs-on: ubuntu-latest
     container:
       # using the same image which is used by opensearch-build team to build the OpenSearch Distribution
       # this image tag is subject to change as more dependencies and updates will arrive over time
       image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
-      # need to switch to root so that github actions can install runner binary on container without permission issues.
       options: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-options }}
 
     steps:
       - name: Run start commands
         run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set Up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1
+      - name: Set up JDK ${{ matrix.java }} for build and test
+        uses: actions/setup-java@v4
         with:
+          distribution: temurin # Temurin is a distribution of adoptium
           java-version: ${{ matrix.java }}
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
@@ -56,7 +53,7 @@ jobs:
           mv -v build/distributions/$plugin ./
           echo "build-test-linux=$plugin" >> $GITHUB_OUTPUT
       - name: Uploads coverage
-        uses: codecov/codecov-action@v1.2.1
+        uses: codecov/codecov-action@v5.0.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
       - uses: actions/upload-artifact@v4
@@ -66,21 +63,19 @@ jobs:
           if-no-files-found: error
 
   linux-test-docker:
-    needs: linux-build
     strategy:
       matrix:
-        java:
-          - 11
-          - 17
-          - 21
+        java: [ 21 ]
+    needs: linux-build
     # Job name
     name: Test Asynchronous Search with opensearchstaging docker
     # This job runs on Linux.
     runs-on: ubuntu-latest
+
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
       - name: Set Up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: ${{ matrix.java }}
@@ -147,16 +142,21 @@ jobs:
           path: build/testclusters/integTest-*/logs/*
 
   windows-build:
+    strategy:
+      matrix:
+        java: [ 21 ]
     # Job name
     name: Windows - Build Asynchronous Search
     # This job runs on Windows.
     runs-on: windows-latest
+
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set Up JDK 11
-        uses: actions/setup-java@v1
+      - name: Set Up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
         with:
-          java-version: 11
+          distribution: temurin # Temurin is a distribution of adoptium
+          java-version: ${{ matrix.java }}
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
         uses: actions/checkout@v4
@@ -176,16 +176,21 @@ jobs:
           path: asynchronous-search-artifacts
 
   mac-os-build:
+    strategy:
+      matrix:
+        java: [ 21 ]
     # Job name
     name: MacOS - Build Asynchronous Search
     # This job runs on Mac OS.
     runs-on: macos-latest
+
     steps:
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set Up JDK 11
-        uses: actions/setup-java@v1
+      - name: Set Up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
         with:
-          java-version: 11
+          distribution: temurin # Temurin is a distribution of adoptium
+          java-version: ${{ matrix.java }}
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
         uses: actions/checkout@v4

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -9,6 +9,10 @@ on:
 
 jobs:
   build-and-publish-snapshots:
+    strategy:
+      matrix:
+        java: [ 21 ]
+
     runs-on: ubuntu-latest
 
     permissions:
@@ -16,11 +20,12 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/setup-java@v3
+      - name: Set Up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
         with:
           distribution: temurin # Temurin is a distribution of adoptium
-          java-version: 11
-      - uses: actions/checkout@v3
+          java-version: ${{ matrix.java }}
+      - uses: actions/checkout@v4
       - uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}

--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -1,7 +1,5 @@
 name: Multi node test workflow
 
-env:
-  java_version: 11
 # This workflow is triggered on pull requests to master
 on:
   pull_request:
@@ -18,8 +16,11 @@ jobs:
       product: opensearch
 
   build:
-    # Job name
+    strategy:
+      matrix:
+        java: [ 21 ]
     needs: Get-CI-Image-Tag
+    # Job name
     name: Build Asynchronous Search
     # This job runs on Linux
     runs-on: ubuntu-latest
@@ -27,21 +28,21 @@ jobs:
       # using the same image which is used by opensearch-build team to build the OpenSearch Distribution
       # this image tag is subject to change as more dependencies and updates will arrive over time
       image: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-version-linux }}
-      # need to switch to root so that github actions can install runner binary on container without permission issues.
-      options: --user root
-
-    env:
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+      options: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-options }}
 
     steps:
+      - name: Run start commands
+        run: ${{ needs.Get-CI-Image-Tag.outputs.ci-image-start-command }}
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set Up JDK 11
-        uses: actions/setup-java@v1
+      - name: Set Up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
         with:
-          java-version: ${{ env.java_version }}
+          distribution: temurin # Temurin is a distribution of adoptium
+          java-version: ${{ matrix.java }}
+
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Run integration tests with multi node config
         run: |
           chown -R 1000:1000 `pwd`
@@ -52,7 +53,7 @@ jobs:
           chown -R 1000:1000 `pwd`
           su `id -un 1000` -c "./gradlew bwcTestSuite -Dtests.security.manager=false"
       - name: Upload failed logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: logs

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -13,19 +13,21 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [11,17,21]
+        java: [21]
     # Job name
     name: Build Asynchronous Search with JDK ${{ matrix.java }}
     # This job runs on Linux
     runs-on: ubuntu-latest
+
     steps:
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
       - name: Set Up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: temurin # Temurin is a distribution of adoptium
           java-version: ${{ matrix.java }}
 
       # Building zip, deb and rpm files
@@ -116,7 +118,7 @@ jobs:
           asset_content_type: application/zip
 
       - name: Upload Workflow Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: asynchronous-search-plugin
           path: asynchronous-search-artifacts


### PR DESCRIPTION
### Description

The following two changes are required to support bumping GHA versions to match main.
Currently CI/CD is failing on 2.19 due to deprecated GHAs (upload-artifact@v3).

Bump JDK version 11 -> 21
- https://github.com/opensearch-project/asynchronous-search/pull/582

Backport custom start command option for runner container
- https://github.com/opensearch-project/asynchronous-search/pull/676
- https://github.com/opensearch-project/asynchronous-search/pull/683

### Related Issues
N/A

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/asynchronous-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
