### PR TITLE
Remove dependency on netty4 client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -148,7 +148,6 @@ dependencies {
     testImplementation "org.opensearch.plugin:lang-painless:${opensearch_version}"
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
     compileOnly "org.opensearch.plugin:opensearch-scripting-painless-spi:${versions.opensearch}"
-    compileOnly "org.opensearch.plugin:transport-netty4-client:${opensearch_version}"
     compileOnly "org.opensearch:opensearch:${opensearch_version}"
     implementation "org.opensearch:common-utils:${common_utils_version}"
     configurations.all {


### PR DESCRIPTION
### Description
`org.opensearch.plugin:transport-netty4-client` listed as compile time dependency in build.gradle but is not needed.
As far as I can tell this is an old artifact which is no longer used.

### Related Issues
N/A

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/asynchronous-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
