### PR TITLE
Bump gradle to 8.14.3 and use jdk 24 in ci workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
   linux-build:
     strategy:
       matrix:
-        java: [21, 23]
+        java: [21, 24]
     needs: Get-CI-Image-Tag
     # Job name
     name: Linux - Build Asynchronous Search
@@ -144,7 +144,7 @@ jobs:
   windows-build:
     strategy:
       matrix:
-        java: [21, 23]
+        java: [21, 24]
     # Job name
     name: Windows - Build Asynchronous Search
     # This job runs on Windows.
@@ -178,7 +178,7 @@ jobs:
   mac-os-build:
     strategy:
       matrix:
-        java: [21, 23]
+        java: [21, 24]
     # Job name
     name: MacOS - Build Asynchronous Search
     # This job runs on Mac OS.

--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [21, 23]
+        java: [21, 24]
     needs: Get-CI-Image-Tag
     # Job name
     name: Build Asynchronous Search

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ buildscript {
 
 plugins {
     id "de.undercouch.download" version "5.6.0"
-    id 'com.netflix.nebula.ospackage' version "11.10.0"
+    id 'com.netflix.nebula.ospackage' version "12.0.0"
     id "com.diffplug.spotless" version "6.25.0"
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=2ab88d6de2c23e6adae7363ae6e29cbdd2a709e992929b48b6530fd0c7133bd6
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionSha256Sum=ed1a8d686605fd7c23bdf62c7fc7add1c5b23b2bbc3721e661934ef4a4911d7c
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### Description

Bump gradle to 8.14 and use jdk 24 in ci workflow

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/asynchronous-search/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
