### PR TITLE
Upgrade Gradle wrapper to 9.4.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=16f2b95838c1ddcf7242b1c39e7bbbb43c842f1f1a1a0dc4959b6d4d68abcac3
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-all.zip
+distributionSha256Sum=708d2c6ecc97ca9a11838ef64a6c2301151b8dd10387e22dc1a12c30557cab5b
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### Description
The OpenSearch `GlobalBuildInfoPlugin` now requires Gradle 9.4.1+. The wrapper was pinned to 9.2.0, causing CI failures:

```
Failed to apply plugin class 'org.opensearch.gradle.info.GlobalBuildInfoPlugin'.
> Gradle 9.4.1+ is required
```

This PR updates `gradle/wrapper/gradle-wrapper.properties` to use Gradle 9.4.1 with the correct SHA-256 checksum.

### Testing
CI should pass with the updated wrapper.