### PR TITLE
Add ci.opensearch.org maven2 mirror to avoid throttling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ buildscript {
 
     repositories {
         mavenLocal()
+        maven { url "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
@@ -49,6 +50,7 @@ plugins {
 
 repositories {
     mavenLocal()
+    maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-
+pluginManagement {
+    repositories {
+        maven { url "https://ci.opensearch.org/maven2/" }
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
 
 rootProject.name = 'asynchronous-search'


### PR DESCRIPTION
### Description
Add ci.opensearch.org maven2 mirror to avoid maven central throttling

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6062

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).