### PR TITLE
Add Eclipse P2 mirror to avoid download.eclipse.org outages (asynchronous-search)

### DIFF
--- a/gradle/formatting.gradle
+++ b/gradle/formatting.gradle
@@ -18,7 +18,7 @@ allprojects {
             target '**/*.java'
 
             removeUnusedImports()
-            eclipse().configFile rootProject.file('formatter/formatterConfig.xml')
+            eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('formatter/formatterConfig.xml')
             trimTrailingWhitespace()
             endWithNewline();
 


### PR DESCRIPTION
### Description
Add `withP2Mirrors` to Spotless eclipse formatter to use `ci.opensearch.org/eclipse/` CloudFront mirror instead of hitting `download.eclipse.org` directly. This prevents CI failures when Eclipse's download server is down or slow.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6421#issuecomment-5271186726

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).